### PR TITLE
Backoff schedule

### DIFF
--- a/func.go
+++ b/func.go
@@ -8,4 +8,4 @@ import (
 //
 // When the given context is done, the function must gracefully terminate
 // whatever logic it's executing.
-type Func func(context.Context)
+type Func func(context.Context) error

--- a/group_test.go
+++ b/group_test.go
@@ -13,7 +13,7 @@ func TestGroupLen(t *testing.T) {
 	defer group.Kill()
 
 	ok := make(chan struct{})
-	f := func(context.Context) { close(ok) }
+	f := func(context.Context) error { close(ok); return nil }
 
 	group.Add(f, Every(time.Second))
 	group.Add(f, Every(time.Minute))
@@ -28,7 +28,7 @@ func TestGroupStart(t *testing.T) {
 	defer group.Kill()
 
 	ok := make(chan struct{})
-	f := func(context.Context) { close(ok) }
+	f := func(context.Context) error { close(ok); return nil }
 
 	group.Add(f, Every(time.Second*10))
 	group.Start()
@@ -50,9 +50,10 @@ func TestGroupStop(t *testing.T) {
 	defer group.Kill()
 
 	ok := make(chan struct{})
-	f := func(context.Context) {
+	f := func(context.Context) error {
 		ok <- struct{}{}
 		<-ok
+		return nil
 	}
 
 	group.Add(f, Every(time.Second))
@@ -84,9 +85,10 @@ func TestGroupStopWithVisitBlocking(t *testing.T) {
 	ok := make(chan struct{})
 	defer close(ok)
 
-	f := func(context.Context) {
+	f := func(context.Context) error {
 		ok <- struct{}{}
 		<-ok
+		return nil
 	}
 
 	group.Add(f, Every(time.Second))
@@ -117,9 +119,9 @@ func TestGroupStopStart(t *testing.T) {
 	ok := make(chan struct{})
 	defer close(ok)
 
-	f := func(context.Context) {
+	f := func(context.Context) error {
 		ok <- struct{}{}
-
+		return nil
 	}
 
 	group.Add(f, Every(time.Second))

--- a/schedule.go
+++ b/schedule.go
@@ -23,7 +23,7 @@ import (
 // If any other error is returned, the task won't execute the function, however
 // if the returned interval is greater than zero it will re-try to run the
 // schedule function after that amount of time.
-type Schedule func() (time.Duration, error)
+type Schedule func(err error) (time.Duration, error)
 
 // ErrSkip is a special error that may be returned by a Schedule function to
 // mean to skip a particular execution of the task function, and just wait the
@@ -32,14 +32,13 @@ var ErrSkip = errors.Errorf("skip execution of task function")
 
 // Every returns a Schedule that always returns the given time interval.
 func Every(interval time.Duration, options ...EveryOption) Schedule {
-	every := &every{}
+	opt := new(every)
 	for _, option := range options {
-		option(every)
+		option(opt)
 	}
 	first := true
-	return func() (time.Duration, error) {
-		var err error
-		if first && every.skipFirst {
+	return func(err error) (time.Duration, error) {
+		if first && opt.skipFirst {
 			err = ErrSkip
 		}
 		first = false
@@ -52,14 +51,76 @@ func Daily(options ...EveryOption) Schedule {
 	return Every(24*time.Hour, options...)
 }
 
+type everyOption interface {
+	setSkipFirst(bool)
+}
+
 // SkipFirst is an option for the Every schedule that will make the schedule
-// skip the very first invokation of the task function.
-var SkipFirst = func(every *every) { every.skipFirst = true }
+// skip the very first invocation of the task function.
+var SkipFirst = func(every everyOption) { every.setSkipFirst(true) }
 
 // EveryOption captures a tweak that can be applied to the Every schedule.
-type EveryOption func(*every)
+type EveryOption func(everyOption)
 
 // Captures options for the Every schedule.
 type every struct {
 	skipFirst bool // If true, return ErrSkip at the very first execution
+}
+
+func (e *every) setSkipFirst(b bool) {
+	e.skipFirst = b
+}
+
+// ErrBackoff is a special error that may be returned by a Schedule function to
+// mean backoff the interval, before re-evaluating the interval of the next
+// execution.
+var ErrBackoff = errors.Errorf("skip execution of task function")
+
+// Backoff returns a Schedule that will attempt to backoff if there is a error
+// passed.
+func Backoff(interval time.Duration, options ...BackoffOption) Schedule {
+	opt := new(backoff)
+	for _, option := range options {
+		option(opt)
+	}
+	var (
+		amount           = 1
+		originalInterval = interval
+	)
+	return func(err error) (time.Duration, error) {
+		// Attempt to handle the backing off
+		if err == nil {
+			amount = 1
+			interval = originalInterval
+		} else if err == ErrBackoff && opt.backoff != nil {
+			interval = opt.backoff(amount, originalInterval)
+			amount++
+		}
+		return interval, err
+	}
+}
+
+type fnBackoff func(n int, t time.Duration) time.Duration
+
+type backoffOption interface {
+	setBackoff(fnBackoff)
+}
+
+// BackoffOption captures a tweak that can be applied to the Backoff schedule.
+type BackoffOption func(backoffOption)
+
+// Captures options for the Backoff schedule.
+type backoff struct {
+	backoff fnBackoff
+}
+
+func (e *backoff) setBackoff(f fnBackoff) {
+	e.backoff = f
+}
+
+// Linear describes a backoff function that grows linearly with time.
+var Linear = func(backoff backoffOption) {
+	backoff.setBackoff(func(n int, t time.Duration) time.Duration {
+		return t * time.Duration(n)
+	})
 }

--- a/schedule_test.go
+++ b/schedule_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestEvery(t *testing.T) {
 	fn := Every(time.Second)
-	interval, err := fn()
+	interval, err := fn(nil)
 	if err != nil {
 		t.Errorf("expected err to be nil")
 	}
@@ -18,9 +18,50 @@ func TestEvery(t *testing.T) {
 
 func TestEveryWithOption(t *testing.T) {
 	fn := Every(time.Second, SkipFirst)
-	interval, err := fn()
+	interval, err := fn(nil)
 
 	if expected, actual := ErrSkip, err; expected != actual {
+		t.Errorf("expected: %v, actual: %v", expected, actual)
+	}
+	if expected, actual := time.Second, interval; expected != actual {
+		t.Errorf("expected: %d, actual: %d", expected, actual)
+	}
+}
+
+func TestBackoff(t *testing.T) {
+	fn := Backoff(time.Second)
+	interval, err := fn(nil)
+	if err != nil {
+		t.Errorf("expected err to be nil")
+	}
+	if expected, actual := time.Second, interval; expected != actual {
+		t.Errorf("expected: %d, actual: %d", expected, actual)
+	}
+}
+
+func TestBackoffWithOption(t *testing.T) {
+	fn := Backoff(time.Second, Linear)
+
+	interval, err := fn(nil)
+	if expected, actual := true, err == nil; expected != actual {
+		t.Errorf("expected: %v, actual: %v", expected, actual)
+	}
+	if expected, actual := time.Second, interval; expected != actual {
+		t.Errorf("expected: %d, actual: %d", expected, actual)
+	}
+
+	for i := 1; i < 5; i++ {
+		interval, err = fn(ErrBackoff)
+		if expected, actual := ErrBackoff, err; expected != actual {
+			t.Errorf("expected: %v, actual: %v", expected, actual)
+		}
+		if expected, actual := time.Second*time.Duration(i), interval; expected != actual {
+			t.Errorf("expected: %d, actual: %d", expected, actual)
+		}
+	}
+
+	interval, err = fn(nil)
+	if expected, actual := true, err == nil; expected != actual {
 		t.Errorf("expected: %v, actual: %v", expected, actual)
 	}
 	if expected, actual := time.Second, interval; expected != actual {

--- a/start_test.go
+++ b/start_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestStart(t *testing.T) {
 	ok := make(chan struct{})
-	f := func(context.Context) { close(ok) }
+	f := func(context.Context) error { close(ok); return nil }
 
 	stop, _ := Start(f, Every(time.Second))
 

--- a/task.go
+++ b/task.go
@@ -42,12 +42,13 @@ func (t *Task) Reset() {
 func (t *Task) loop(ctx context.Context) {
 	// Kick off the task immediately (as long as the the schedule is
 	// greater than zero, see below).
+	var fErr error
 	delay := immediately
 
 	for {
 		var timer <-chan time.Time
 
-		schedule, err := t.schedule()
+		schedule, err := t.schedule(fErr)
 		switch err {
 		case ErrSkip:
 			// Reset the delay to be exactly the schedule, so we
@@ -84,7 +85,7 @@ func (t *Task) loop(ctx context.Context) {
 				// Execute the task function synchronously. Consumers
 				// are responsible for implementing proper cancellation
 				// of the task function itself using the tomb's context.
-				t.f(ctx)
+				fErr = t.f(ctx)
 				delay = schedule
 			} else {
 				// Don't execute the task function, and set the


### PR DESCRIPTION
In order to make the task library more powerful in terms of scheduling,
the task function now allows to carry forward a returned error. Using
this error allows us to identify if a backoff is required during a
schedule. With this setup we can then do clever things around burst
timings for tasks and sleeping patterns.