### PR TITLE
Surpress backoff error

### DIFF
--- a/schedule.go
+++ b/schedule.go
@@ -84,17 +84,17 @@ func Backoff(interval time.Duration, options ...BackoffOption) Schedule {
 		option(opt)
 	}
 	var (
-		amount           = 1
+		amount           = 0
 		originalInterval = interval
 	)
 	return func(err error) (time.Duration, error) {
 		// Attempt to handle the backing off
 		if err == nil {
-			amount = 1
+			amount = 0
 			interval = originalInterval
 		} else if err == ErrBackoff && opt.backoff != nil {
-			interval = opt.backoff(amount, originalInterval)
 			amount++
+			return opt.backoff(amount, originalInterval), nil
 		}
 		return interval, err
 	}

--- a/schedule_test.go
+++ b/schedule_test.go
@@ -52,7 +52,7 @@ func TestBackoffWithOption(t *testing.T) {
 
 	for i := 1; i < 5; i++ {
 		interval, err = fn(ErrBackoff)
-		if expected, actual := ErrBackoff, err; expected != actual {
+		if expected, actual := true, err == nil; expected != actual {
 			t.Errorf("expected: %v, actual: %v", expected, actual)
 		}
 		if expected, actual := time.Second*time.Duration(i), interval; expected != actual {


### PR DESCRIPTION
The following will surpress the backoff error to ensure that it doesn't
propergate through to the next task.