### PR TITLE
Wait abstraction

### DIFF
--- a/wait/wait.go
+++ b/wait/wait.go
@@ -1,0 +1,79 @@
+package wait
+
+import (
+	"context"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// Option to be passed to Wait to customize the resulting instance.
+type Option func(*options)
+
+type options struct {
+	clock Clock
+}
+
+// WithClock sets the sleeper on the options
+func WithClock(clock Clock) Option {
+	return func(options *options) {
+		if clock != nil {
+			options.clock = clock
+		}
+	}
+}
+
+// Create a options instance with default values.
+func newOptions() *options {
+	return &options{
+		clock: wallClock{},
+	}
+}
+
+// Clock represents the passage of time in a way that
+// can be faked out for tests.
+type Clock interface {
+	// After waits for the duration to elapse and then sends the current time
+	// on the returned channel.
+	// It is equivalent to NewTimer(d).C.
+	// The underlying Timer is not recovered by the garbage collector
+	// until the timer fires. If efficiency is a concern, use NewTimer
+	// instead and call Timer.Stop if the timer is no longer needed.
+	After(d time.Duration) <-chan time.Time
+}
+
+// Wait represents an abstraction for waiting for a given function to be called
+// and if it doesn't complete within a given time frame, an error is called and
+// the context notes that it's done.
+//
+// This is useful when waiting upon a given thing to happen, but don't mind
+// blocking for that to happen.
+func Wait(fn func(context.Context), timeout time.Duration, options ...Option) error {
+	opts := newOptions()
+	for _, option := range options {
+		option(opts)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	ch := make(chan struct{})
+	go func() {
+		fn(ctx)
+		ch <- struct{}{}
+	}()
+
+	select {
+	case <-ch:
+		return nil
+	case <-opts.clock.After(timeout):
+		return errors.Errorf("timed out waiting for completion")
+	}
+}
+
+// wallClock implements a Clock in terms of a standard time function
+type wallClock struct{}
+
+func (wallClock) After(d time.Duration) <-chan time.Time {
+	return time.After(d)
+}

--- a/wait/wait_test.go
+++ b/wait/wait_test.go
@@ -1,0 +1,46 @@
+package wait
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestWait(t *testing.T) {
+	t.Parallel()
+
+	t.Run("run", func(t *testing.T) {
+		var called bool
+		err := Wait(func(ctx context.Context) {
+			called = true
+		}, time.Millisecond*50)
+
+		if err != nil {
+			t.Error(err)
+		}
+		if expected, actual := true, called; expected != actual {
+			t.Errorf("expected: %v, actual: %v", expected, actual)
+		}
+	})
+
+	t.Run("run long process", func(t *testing.T) {
+		var called bool
+		err := Wait(func(ctx context.Context) {
+			time.Sleep(time.Millisecond * 100)
+			select {
+			case <-ctx.Done():
+				called = true
+			case <-time.After(time.Millisecond * 100):
+				t.Errorf("failed to wait for done")
+			}
+		}, time.Millisecond*50)
+
+		if expected, actual := "timed out waiting for completion", err.Error(); expected != actual {
+			t.Errorf("expected: %v, actual: %v", expected, actual)
+		}
+		time.Sleep(time.Millisecond * 50)
+		if expected, actual := true, called; expected != actual {
+			t.Errorf("expected: %v, actual: %v", expected, actual)
+		}
+	})
+}


### PR DESCRIPTION
Wait implements a basic abstraction to wait for a given function to
complete. If the function takes too long, then a completion is failed
with the timeout triggering.