### PR TITLE
Allow occupy to skip tasks

### DIFF
--- a/guard/occupy.go
+++ b/guard/occupy.go
@@ -4,6 +4,9 @@ import (
 	"github.com/pkg/errors"
 )
 
+// ErrSkip will tell the occupy to skip task execution.
+var ErrSkip = errors.Errorf("skip task execution")
+
 // Task describes any type whose validity and/or activity is bounded
 // in time. Most frequently, they will represent the duration of some
 // task or tasks running on internal goroutines, but it's possible and
@@ -80,6 +83,9 @@ func Occupy(guard Guest, start StartFunc, abort <-chan struct{}) (Task, error) {
 				return nil, errors.WithStack(err)
 			}
 		case err := <-failed:
+			if errors.Cause(err) == ErrSkip {
+				return nil, nil
+			}
 			return nil, errors.WithStack(err)
 		case tsk := <-started:
 			return tsk, nil

--- a/guard/occupy_test.go
+++ b/guard/occupy_test.go
@@ -117,6 +117,26 @@ func TestStartSuccess(t *testing.T) {
 	}
 }
 
+func TestStartSkip(t *testing.T) {
+	guard := New()
+	defer assertGuardStopped(t, guard)
+
+	err := guard.Unlock()
+	if err != nil {
+		t.Errorf("expected err to be nil, actual: %v", err)
+	}
+
+	task, err := Occupy(guard, func() (Task, error) {
+		return nil, ErrSkip
+	}, nil)
+	if err != nil {
+		t.Errorf("expected err to be nil, actual: %v", err)
+	}
+	if expected, actual := true, task == nil; expected != actual {
+		t.Errorf("expected %v, actual: %v", expected, actual)
+	}
+}
+
 type task struct {
 	tomb *tomb.Tomb
 }


### PR DESCRIPTION
Sometimes we don't have a task to execute on and it would be wrong to
expect occupy to do something. Instead we add the concept of skipping
which will keep the abstraction inside of occupy. This means that occupy
can identify when a skip is called and just continue onwards.