### PR TITLE
Tomb keep-alive

### DIFF
--- a/tomb/context.go
+++ b/tomb/context.go
@@ -7,7 +7,7 @@ import "context"
 // that is closed when either the tomb is dying or the parent is canceled.
 // The returned context may also be obtained via the tomb's Context method.
 func WithContext(parent context.Context) (*Tomb, context.Context) {
-	t := New()
+	t := New(false)
 	if parent.Done() != nil {
 		go func() {
 			select {

--- a/tomb/context_test.go
+++ b/tomb/context_test.go
@@ -111,7 +111,7 @@ func TestWithContext(t *testing.T) {
 }
 
 func TestContextNoParent(t *testing.T) {
-	tb := New()
+	tb := New(false)
 
 	parent2, cancel2 := context.WithCancel(context.WithValue(context.Background(), parent, grandParent))
 	child2 := tb.Context(parent2)


### PR DESCRIPTION
There are scenarios where we want to have a tomb keep running until it's
killed, rather than it self terminating once the go routines have
finished.

This is somewhat pushing the limits of a tomb and we could have another
name for this, but essentially we are where we are.