### PR TITLE
Adding catacomb to tasks library.

### DIFF
--- a/tomb/catacomb.go
+++ b/tomb/catacomb.go
@@ -1,0 +1,124 @@
+package tomb
+
+import (
+	"sync"
+
+	"github.com/pkg/errors"
+)
+
+// Catacomb is a variant of Tomb with its own internal goroutine, designed
+// for coordinating the lifetimes of tombs needed by a single parent.
+type Catacomb struct {
+	tomb  *Tomb
+	wg    sync.WaitGroup
+	tombs chan *Tomb
+}
+
+// NewCatacomb creates a new catacomb to process tombs.
+func NewCatacomb() *Catacomb {
+	return &Catacomb{
+		tomb:  New(false),
+		tombs: make(chan *Tomb),
+	}
+}
+
+// Add causes the supplied tomb's lifetime to be bound to the catacomb's,
+// relieving the client of responsibility for Kill()ing it and Wait()ing for an
+// error, *whether or not this method succeeds*. If the method returns an error,
+// it always indicates that the catacomb is shutting down; the value will either
+// be the error from the (now-stopped) tomb, or catacomb.ErrDying().
+//
+// If the tomb completes without error, the catacomb will continue unaffected;
+// otherwise the catacomb's tomb will be killed with the returned error. This
+// allows clients to freely Kill() tombs that have been Add()ed; any errors
+// encountered will still kill the catacomb, so the tombs stay under control
+// until the last moment, and so can be managed pretty casually once they've
+// been added.
+//
+// Don't try to add a tomb to its own catacomb; that'll deadlock the shutdown
+// procedure. I don't think there's much we can do about that.
+func (c *Catacomb) Add(t *Tomb) error {
+	select {
+	case <-c.tomb.Dying():
+		if err := Stop(t); err != nil {
+			return errors.WithStack(err)
+		}
+		return c.ErrDying()
+	case c.tombs <- t:
+		// Note that we don't need to wait for confirmation here. This depends
+		// on the catacomb.wg.Add() for the listen loop, which ensures the wg
+		// won't complete until no more adds can be received.
+		return nil
+	}
+}
+
+// Dying returns a channel that will be closed when Kill is called.
+func (c *Catacomb) Dying() <-chan struct{} {
+	return c.tomb.Dying()
+}
+
+// Dead returns a channel that will be closed when Invoke has completed (and
+// thus when subsequent calls to Wait() are known not to block).
+func (c *Catacomb) Dead() <-chan struct{} {
+	return c.tomb.Dead()
+}
+
+// Wait blocks until Invoke completes, and returns the first non-nil and
+// non-tomb.ErrDying error passed to Kill before Invoke finished.
+func (c *Catacomb) Wait() error {
+	return c.tomb.Wait()
+}
+
+// Err returns the reason for the tomb death provided via Kill
+// or Killf, or ErrStillAlive when the tomb is still alive.
+func (c *Catacomb) Err() error {
+	return c.tomb.Err()
+}
+
+// ErrDying returns an error that can be used to Kill *this* catacomb without
+// overwriting nil errors. It should only be used when the catacomb is already
+// known to be dying; calling this method at any other time will return a
+// different error, indicating client misuse.
+func (c *Catacomb) ErrDying() error {
+	select {
+	case <-c.tomb.Dying():
+		return ErrDying
+	default:
+		return errors.New("bad catacomb ErrDying: still alive")
+	}
+}
+
+// Kill will kill the Catacomb's internal tomb with the supplied error, or one
+// derived from it.
+//
+// It's always safe to call Kill, but errors passed to Kill after the catacomb
+// is dead will be ignored.
+func (c *Catacomb) Kill(err error) error {
+	return c.tomb.Kill(err)
+}
+
+// add starts two goroutines that (1) kill the catacomb's tomb with any
+// error encountered by the tomb; and (2) kill the tomb when the
+// catacomb starts dying.
+func (c *Catacomb) add(t *Tomb) {
+	c.wg.Add(2)
+
+	done := make(chan struct{})
+	go func() {
+		defer c.wg.Done()
+		defer close(done)
+
+		if err := t.Wait(); err != nil {
+			c.Kill(err)
+		}
+	}()
+
+	go func() {
+		defer c.wg.Done()
+		select {
+		case <-c.tomb.Dying():
+			Stop(t)
+		case <-done:
+		}
+	}()
+}

--- a/tomb/catacomb_test.go
+++ b/tomb/catacomb_test.go
@@ -1,1 +1,174 @@
 package tomb
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+func TestStartsAlive(t *testing.T) {
+	t.Parallel()
+
+	err := run(t, func(ctx context.Context) error {
+		c := ctxCatacomb(t, ctx)
+		assertNotDying(t, c)
+		assertNotDead(t, c)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected err to be nil, %v", err)
+	}
+}
+
+func TestKillClosesDying(t *testing.T) {
+	t.Parallel()
+
+	err := run(t, func(ctx context.Context) error {
+		c := ctxCatacomb(t, ctx)
+		c.Kill(nil)
+		assertDying(t, c)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected err to be nil, %v", err)
+	}
+}
+
+func TestKillDoesNotCloseDead(t *testing.T) {
+	t.Parallel()
+
+	err := run(t, func(ctx context.Context) error {
+		c := ctxCatacomb(t, ctx)
+		c.Kill(nil)
+		assertNotDead(t, c)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected err to be nil, %v", err)
+	}
+}
+
+func TestKillNonNilOverwritesNil(t *testing.T) {
+	t.Parallel()
+
+	second := errors.Errorf("boom")
+	err := run(t, func(ctx context.Context) error {
+		c := ctxCatacomb(t, ctx)
+		c.Kill(nil)
+		c.Kill(second)
+		return nil
+	})
+	if expected, actual := "boom", err.Error(); expected != actual {
+		t.Fatalf("expected: %v, actual: %v", expected, actual)
+	}
+}
+
+func TestKillNonNilOverwritesNonNil(t *testing.T) {
+	t.Parallel()
+
+	first := errors.Errorf("boom")
+	err := run(t, func(ctx context.Context) error {
+		c := ctxCatacomb(t, ctx)
+		c.Kill(first)
+		c.Kill(nil)
+		return nil
+	})
+	if expected, actual := "boom", err.Error(); expected != actual {
+		t.Fatalf("expected: %v, actual: %v", expected, actual)
+	}
+}
+
+func TestKillAliveErrDying(t *testing.T) {
+	t.Parallel()
+
+	var notDying error
+	err := run(t, func(ctx context.Context) error {
+		c := ctxCatacomb(t, ctx)
+		notDying = c.ErrDying()
+		c.Kill(notDying)
+		return nil
+	})
+	if expected, actual := notDying, err; expected != actual {
+		t.Fatalf("expected: %v, actual: %v", expected, actual)
+	}
+}
+
+func run(t *testing.T, task func(ctx context.Context) error) error {
+	t.Helper()
+
+	c, err := Invoke(task)
+	if err != nil {
+		t.Fatalf("expected err to be nil, %v", err)
+	}
+
+	select {
+	case <-c.Dead():
+	case <-time.After(time.Millisecond * 250):
+		t.Fatalf("timed out waiting for death")
+	}
+	return c.Wait()
+}
+
+func waitDying(t *testing.T, c *Catacomb) {
+	t.Helper()
+
+	if err := Wait(c, time.Millisecond*250); err != nil {
+		t.Errorf("expected err to be nil, %v", err)
+	}
+}
+
+func assertDying(t *testing.T, c *Catacomb) {
+	t.Helper()
+
+	select {
+	case <-c.Dying():
+	default:
+		t.Fatalf("still alive")
+	}
+}
+
+func assertNotDying(t *testing.T, c *Catacomb) {
+	t.Helper()
+
+	select {
+	case <-c.Dying():
+		t.Fatalf("already dying")
+	default:
+	}
+}
+
+func assertDead(t *testing.T, c *Catacomb) {
+	t.Helper()
+
+	select {
+	case <-c.Dead():
+	default:
+		t.Fatalf("not dead")
+	}
+}
+
+func assertNotDead(t *testing.T, c *Catacomb) {
+	t.Helper()
+
+	select {
+	case <-c.Dead():
+		t.Fatalf("already dead")
+	default:
+	}
+}
+
+func ctxCatacomb(t *testing.T, ctx context.Context) *Catacomb {
+	t.Helper()
+
+	src := ctx.Value(TombSource)
+	if src == nil {
+		t.Fatalf("expected valid tomb source")
+	}
+	if c, ok := src.(*Catacomb); ok {
+		return c
+	}
+	t.Fatalf("unexpected tomb source, %T", src)
+	return nil
+}

--- a/tomb/catacomb_test.go
+++ b/tomb/catacomb_test.go
@@ -1,0 +1,1 @@
+package tomb

--- a/tomb/invoke.go
+++ b/tomb/invoke.go
@@ -1,0 +1,44 @@
+package tomb
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+)
+
+// Invoke a set of Tombs to be overseen by a Catacomb.
+func Invoke(tombs []*Tomb, fn Func) (*Catacomb, error) {
+	catacomb := NewCatacomb()
+
+	for _, tomb := range tombs {
+		catacomb.add(tomb)
+	}
+
+	// This goroutine listens for added tombs until the catacomb is Killed.
+	// We ensure the wg can't complete until we know no new tombs will be
+	// added.
+	catacomb.wg.Add(1)
+	go func() {
+		defer catacomb.wg.Done()
+		for {
+			select {
+			case <-catacomb.tomb.Dying():
+				return
+			case w := <-catacomb.tombs:
+				catacomb.add(w)
+			}
+		}
+	}()
+
+	if err := catacomb.tomb.Go(func(ctx context.Context) error {
+		defer catacomb.wg.Wait()
+		return fn(ctx)
+	}); err != nil {
+		for _, tomb := range tombs {
+			err = errors.WithMessage(Stop(tomb), err.Error())
+		}
+		return nil, errors.WithStack(err)
+	}
+
+	return catacomb, nil
+}

--- a/tomb/stop.go
+++ b/tomb/stop.go
@@ -1,0 +1,22 @@
+package tomb
+
+import "github.com/pkg/errors"
+
+// CancellableTask defines a task that can be waited on and also cancelled via
+// a kill method.
+type CancellableTask interface {
+	// Kill asks the task to stop and returns immediately.
+	Kill(error) error
+
+	// Wait waits for the task to complete and returns any error encountered
+	// when it was running or stopping.
+	Wait() error
+}
+
+// Stop kills the given tomb and waits for it to complete.
+func Stop(t CancellableTask) error {
+	if err := t.Kill(nil); err != nil {
+		return errors.WithStack(err)
+	}
+	return t.Wait()
+}

--- a/tomb/wait.go
+++ b/tomb/wait.go
@@ -1,0 +1,24 @@
+package tomb
+
+import (
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// Waitable defines a type that states if it's dead or not.
+type Waitable interface {
+	// Dying returns the channel that can be used to wait until
+	// t.Kill is called.
+	Dying() <-chan struct{}
+}
+
+// Wait for a Waitable to die.
+func Wait(waitable Waitable, duration time.Duration) error {
+	select {
+	case <-waitable.Dying():
+	case <-time.After(duration):
+		return errors.Errorf("timed out waiting for death")
+	}
+	return nil
+}


### PR DESCRIPTION
Catacombs manage many tombs making it easier to construct better models
of types.